### PR TITLE
fix(rsPopoverTrigger): select target using getElementById

### DIFF
--- a/src/javascripts/rsPopoverTrigger.js
+++ b/src/javascripts/rsPopoverTrigger.js
@@ -13,7 +13,8 @@ angular.module('rs.popover').directive('rsPopoverTrigger', function (registry, A
 
   function findPopoverTarget(element, attrs) {
     if (attrs.rsPopoverTarget) {
-      return angular.element('#' + attrs.rsPopoverTarget);
+      var target = document.getElementById('#'+attrs.rsPopoverTarget);
+      return angular.element(target);
     }
 
     return element;
@@ -55,4 +56,3 @@ angular.module('rs.popover').directive('rsPopoverTrigger', function (registry, A
     }
   };
 });
-


### PR DESCRIPTION
@bradgignac: we were having problems setting `rs-popover-target` from a link action in a dropdown to its parent cog within a ng-repeat. At first thought it may be a race issue with attrs and the iteration but I realized this is because Waldo doesn't use jQuery and jqlite can't select by id. How does this change look?