### PR TITLE
Locate rs-popover-target at click-event-time

### DIFF
--- a/src/javascripts/rsPopoverTrigger.js
+++ b/src/javascripts/rsPopoverTrigger.js
@@ -39,15 +39,16 @@ angular.module('rs.popover').directive('rsPopoverTrigger', function (registry, A
     restrict: 'A',
     require: '?^rsPopover',
     link: function (scope, element, attrs, popoverController) {
-      var id, target, corner, data;
+      var id, corner, data;
 
       id = findPopoverId(attrs, popoverController);
-      target = findPopoverTarget(element, attrs);
       corner = findPopoverCorner(attrs);
       data = evalPopoverData(scope, attrs);
 
       element.on('click', function (e) {
         e.preventDefault();
+
+        var target = findPopoverTarget(element, attrs);
 
         registry.popover(id).toggle(target, corner, data);
         scope.$apply();

--- a/test/rsPopoverTriggerSpec.js
+++ b/test/rsPopoverTriggerSpec.js
@@ -38,11 +38,11 @@ describe('rs.popover.rsPopoverTrigger', function () {
   });
 
   describe('rs-popover-target', function () {
-    it('points popover at specified element', inject(function ($compile) {
+    it('points popover at specified element, locating it at click-event-time', inject(function ($compile) {
       var element, target;
 
-      angular.element('body').append('<div id="target"></div>');
       element = $compile('<a rs-popover-trigger="mypopover" rs-popover-target="target"></a>')(scope);
+      angular.element('body').append('<div id="target"></div>');
       scope.$digest();
 
       element.triggerHandler('click');


### PR DESCRIPTION
The rsPopoverTrigger directive will -- in some circumstances -- get
created and run `link()` before templates like the following get a chance
to be evaluated:

```
<some-element id="{{key}}"></some-element>
```

Which means findPopoverTarget won't find it and will throw an error even
though an element with the specified id will eventually exist.

A common case where this may happen is when the rs-popover-target exists
in a repeater and is pointed to an element of the repeater whose id can
only be generated by an angular binding expression.
